### PR TITLE
Add vendor prefixed type properties

### DIFF
--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -1,16 +1,27 @@
 import React, { useEffect } from "react";
 
+// TODO (DF): remove app references in favor of vendor once it is safe
 interface AppstoreContextType {
-  appUserId: string;
-  endAppUserSession: () => void;
-  useAppUserDatastore: () => {
+  appUserId?: string;
+  vendorUserId?: string;
+  endAppUserSession?: () => void;
+  endVendorUserSession?: () => void;
+  useAppUserDatastore?: () => {
     appUserDataLoading: boolean;
     appUserDataCalled: boolean;
     appUserDataError: any;
     appUserData: string | undefined;
     appUserId: string;
   };
-  useSubmitAppUserDatastore: () => [(data: string) => void, any];
+  useVendorUserDatastore?: () => {
+    vendorUserDataLoading: boolean;
+    vendorUserDataCalled: boolean;
+    vendorUserDataError: any;
+    vendorUserData: string | undefined;
+    vendorUserId: string;
+  };
+  useSubmitAppUserDatastore?: () => [(data: string) => void, any];
+  useSubmitVendorUserDatastore?: () => [(data: string) => void, any];
   useMakeApiRequest: (
     input: MakeApiRequestParams,
     skip: boolean
@@ -27,7 +38,8 @@ export interface CustomFieldType {
 }
 
 export interface GetResultsObjectType {
-  appSlug: string;
+  appSlug?: string;
+  vendorSlug?: string;
   subrouteSlug: string;
   dateCompletedAt: Date | string;
   nextAttemptDate: Date | string;
@@ -54,7 +66,8 @@ export interface MakeApiRequestParams {
   body?: string;
 }
 export interface ManifestType {
-  app_slug: string;
+  app_slug?: string;
+  vendor_slug?: string;
   author: string;
   description: string;
   homepage_url: string;

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -3,9 +3,9 @@ import React, { useEffect } from "react";
 // TODO (DF): remove app references in favor of vendor once it is safe
 interface AppstoreContextType {
   appUserId?: string;
-  vendorUserId?: string;
+  appstoreUserId?: string;
   endAppUserSession?: () => void;
-  endVendorUserSession?: () => void;
+  endAppstoreUserSession?: () => void;
   useAppUserDatastore?: () => {
     appUserDataLoading: boolean;
     appUserDataCalled: boolean;
@@ -13,15 +13,15 @@ interface AppstoreContextType {
     appUserData: string | undefined;
     appUserId: string;
   };
-  useVendorUserDatastore?: () => {
-    vendorUserDataLoading: boolean;
-    vendorUserDataCalled: boolean;
-    vendorUserDataError: any;
-    vendorUserData: string | undefined;
-    vendorUserId: string;
+  useDatastore?: () => {
+    dataLoading: boolean;
+    dataCalled: boolean;
+    dataError: any;
+    data: string | undefined;
+    appstoreUserId: string;
   };
   useSubmitAppUserDatastore?: () => [(data: string) => void, any];
-  useSubmitVendorUserDatastore?: () => [(data: string) => void, any];
+  useSubmitDatastore?: () => [(data: string) => void, any];
   useMakeApiRequest: (
     input: MakeApiRequestParams,
     skip: boolean

--- a/lib/index.tsx
+++ b/lib/index.tsx
@@ -2,11 +2,11 @@ import React, { useEffect } from "react";
 
 // TODO (DF): remove app references in favor of vendor once it is safe
 interface AppstoreContextType {
-  appUserId?: string;
+  appUserId: string;
   appstoreUserId?: string;
-  endAppUserSession?: () => void;
+  endAppUserSession: () => void;
   endAppstoreUserSession?: () => void;
-  useAppUserDatastore?: () => {
+  useAppUserDatastore: () => {
     appUserDataLoading: boolean;
     appUserDataCalled: boolean;
     appUserDataError: any;
@@ -20,7 +20,7 @@ interface AppstoreContextType {
     data: string | undefined;
     appstoreUserId: string;
   };
-  useSubmitAppUserDatastore?: () => [(data: string) => void, any];
+  useSubmitAppUserDatastore: () => [(data: string) => void, any];
   useSubmitDatastore?: () => [(data: string) => void, any];
   useMakeApiRequest: (
     input: MakeApiRequestParams,


### PR DESCRIPTION
Not sure if this is the correct way to update these, but I wanted to not break current usages of these types. My plan is to merge this, update the app to use the `vendor` versions of the type properties, and then come back here and remove the `app` ones and make `vendor` required.